### PR TITLE
Fix CORS headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,6 @@ Make sure you have the `Client ID` and `Client Secret` from the above steps.  Yo
 
 The environment variables recognized by the container are as follows:
 
-* ALLOW_HEADERS: The CORS headers to allow for *PROXY_PATH*.  Default: __Header set Access-Control-Allow-Headers "authorization, content-type, accept, origin"__
-* ALLOW_HEADERS2: The CORS headers to allow for *PROXY_PATH2*.  Default:  None
-* ALLOW_METHODS: The CORS methods to allow for *PROXY_PATH*.  Default: __Header set Access-Control-Allow-Methods "GET,POST,PUT,PATCH,DELETE,OPTIONS,HEAD"__
-* ALLOW_METHODS2: The CORS methods to allow for *PROXY_PATH2*.  Default:  None
 * AUTH_REQUIRE: An OIDC claim to restrict access on *PROXY_PATH*.  Default: __Require all granted__
 * AUTH_REQUIRE2: An OIDC claim to restrict access on *PROXY_PATH2*.  Default: __Require valid-user__
 * AUTH_TYPE: The AuthType to use for *PROXY_PATH*.  Default: __AuthType None__
@@ -39,7 +35,6 @@ The environment variables recognized by the container are as follows:
 * SSL_HTTPD_PORT:  The SSL port on which to run Apache.  Default: __443__
 * SSL_PROTOCOL:  The SSL protocols to use when running Apache.  Default: __-SSLv3 -TLSv1 -TLSv1.1 +TLSv1.2__
 * SSL_CIPHER_SUITE:  The SSL cipher suite to use when running Apache.  Default: __ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-SHA:ECDHE-ECDSA-AES256-SHA:ECDHE-ECDSA-DES-CBC3-SHA:ECDHE-RSA-AES128-SHA:ECDHE-RSA-AES256-SHA:ECDHE-RSA-DES-CBC3-SHA:DHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA:EDH-RSA-DES-CBC3-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA:AES256-SHA:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!3DES:!ADH!MD5:!PSK:!aECDH:!EDH-DSS-DES-CBC3-SHA:!EDH-RSA-DES-CBC3-SHA:!KRB5-DES-CBC3-SHA:!DH__
-* X_FRAME_OPTIONS:  The X-Frame-Options header to add to all traffic.  Default: __Header always append X-Frame-Options SAMEORIGIN__
 
 Once all these environment variables are setup correctly, you can run a fully-functional version fo the container that will be setup to communicate with Google for authentication.  The following example fills in some necessary environment variables while inheriting the defaults of others:
 

--- a/run.sh
+++ b/run.sh
@@ -33,26 +33,6 @@ if [ -z "$SERVER_NAME" ] ; then
     export SERVER_NAME=localhost
 fi
 
-# update ALLOW_HEADERS
-if [ -z "$ALLOW_HEADERS" ] ; then
-    export ALLOW_HEADERS='Header set Access-Control-Allow-Headers "authorization, content-type, accept, origin"'
-fi
-
-# set ALLOW_HEADERS2
-if [ -z "$ALLOW_HEADERS2" ] ; then
-    export ALLOW_HEADERS2=
-fi
-
-# update ALLOW_METHODS
-if [ -z "$ALLOW_METHODS" ] ; then
-    export ALLOW_METHODS='Header set Access-Control-Allow-Methods "GET,POST,PUT,PATCH,DELETE,OPTIONS,HEAD"'
-fi
-
-# update ALLOW_METHODS2
-if [ -z "$ALLOW_METHODS2" ] ; then
-    export ALLOW_METHODS2=
-fi
-
 # update AUTH_REQUIRE
 if [ -z "$AUTH_REQUIRE" ] ; then
     # backward compatibility for OIDC_CLAIM
@@ -160,11 +140,6 @@ fi
 # set the SSL Cipher Suite
 if [ -z "$SSL_CIPHER_SUITE" ] ; then
     export SSL_CIPHER_SUITE='ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:kEDH+AESGCM:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA256:DHE-RSA-AES256-SHA256:DHE-DSS-AES256-SHA:DHE-RSA-ES256-SHA:ALL:!3DES:!ADH:!DES:!DH:!EDH-DSS-DES-CBC3-SHA:!EDH-RSA-DES-CBC3-SHA:!EXPORT:!KRB5-DES-CBC3-SHA:!MD5:!PSK:!RC4:!aECDH:!aNULL:!eNULL'
-fi
-
-# set the SSL Cipher Suite
-if [ -z "$X_FRAME_OPTIONS" ] ; then
-    export X_FRAME_OPTIONS='Header always append X-Frame-Options SAMEORIGIN'
 fi
 
 # If there is an override script, pull it in

--- a/site.conf
+++ b/site.conf
@@ -6,7 +6,8 @@ TraceEnable off
 LogFormat "%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" combined
 LogLevel ${LOG_LEVEL}
 
-${X_FRAME_OPTIONS}
+Header unset X-Frame-Options
+Header always set X-Frame-Options SAMEORIGIN
 
 ProxyTimeout ${PROXY_TIMEOUT}
 
@@ -40,9 +41,18 @@ ProxyTimeout ${PROXY_TIMEOUT}
     SSLCertificateChainFile "/etc/ssl/certs/ca-bundle.crt"
 
     <Location ${PROXY_PATH}>
-        Header set Access-Control-Allow-Origin "*"
-        ${ALLOW_HEADERS}
-        ${ALLOW_METHODS}
+        Header unset Access-Control-Allow-Origin
+        Header always set Access-Control-Allow-Origin "*"
+        Header unset Access-Control-Allow-Headers
+        Header always set Access-Control-Allow-Headers "authorization,content-type,accept,origin"
+        Header unset Access-Control-Allow-Methods
+        Header always set Access-Control-Allow-Methods "GET,POST,PUT,PATCH,DELETE,OPTIONS,HEAD"
+        RewriteEngine On
+        RewriteCond %{REQUEST_METHOD} OPTIONS
+        RewriteRule ^(.*)$ $1 [R=204,L]
+        <Limit OPTIONS>
+          Require all granted
+        </Limit>
 
         ${AUTH_TYPE}
 
@@ -50,9 +60,18 @@ ProxyTimeout ${PROXY_TIMEOUT}
     </Location>
 
     <Location ${PROXY_PATH2}>
-        Header set Access-Control-Allow-Origin "*"
-        ${ALLOW_HEADERS2}
-        ${ALLOW_METHODS2}
+        Header unset Access-Control-Allow-Origin
+        Header always set Access-Control-Allow-Origin "*"
+        Header unset Access-Control-Allow-Headers
+        Header always set Access-Control-Allow-Headers "authorization,content-type,accept,origin"
+        Header unset Access-Control-Allow-Methods
+        Header always set Access-Control-Allow-Methods "GET,POST,PUT,PATCH,DELETE,OPTIONS,HEAD"
+        RewriteEngine On
+        RewriteCond %{REQUEST_METHOD} OPTIONS
+        RewriteRule ^(.*)$ $1 [R=204,L]
+        <Limit OPTIONS>
+          Require all granted
+        </Limit>
 
         ${AUTH_TYPE2}
 


### PR DESCRIPTION
- Scrubs existing headers before adding---duplicate headers are not valid.
- Responds with 204 for OPTIONS request so underlying services don't have to implement it.
- Allows any user to make OPTIONS request (since it is done by the browser and won't have authentication information).
- Removes ALLOW_HEADERS, ALLOW_METHODS, and X_FRAME_OPTIONS as configuration parameters, since these are never changed from the default [1][2], so the additional complexity of parameterizing them is not warranted.

[1] https://github.com/search?l=&q=ALLOW_HEADERS+user%3Abroadinstitute&ref=advsearch&type=Code&utf8=%E2%9C%93
[2] https://github.com/search?utf8=%E2%9C%93&q=X_FRAME_OPTIONS+user%3Abroadinstitute&type=Code&ref=searchresults
