### PR TITLE
AllowEncodedSlashes NoDecode

### DIFF
--- a/site.conf
+++ b/site.conf
@@ -19,6 +19,7 @@ ProxyTimeout ${PROXY_TIMEOUT}
 <VirtualHost _default_:${SSL_HTTPD_PORT}>
 
     DocumentRoot /app
+    AllowEncodedSlashes NoDecode
 
     <Directory "/app">
         AllowOverride All


### PR DESCRIPTION
before this change apache will discard a URL with an encoded slash (%2F). This allows the encoded slash to go through to the application.
