### PR TITLE
bumped openidc version to 1.8.10.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM phusion/baseimage:0.9.22
 MAINTAINER Andrew Teixeira <teixeira@broadinstitute.org>
 
 ENV DEBIAN_FRONTEND=noninteractive \
-    OPENIDC_VERSION=1.8.9 \
+    OPENIDC_VERSION=1.8.10.1 \
     PHUSION_BASEIMAGE=0.9.22
 
 ADD . /tmp/build


### PR DESCRIPTION
NOTE: there is actually a newer version 1.8.10.3 that consists of a backported security patch - however the openidc git repo did not build a debian package for the .3 version - which is required for the current build process.   Openidc git site recommends that users should be using 2.1.6 or greater (since that is the version the security update was backported from)

Also skipping version 1.8.10 since this point release has another security related update applied.