### PR TITLE
bumping openidc version to 2.0.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM phusion/baseimage:0.9.22
 MAINTAINER Andrew Teixeira <teixeira@broadinstitute.org>
 
 ENV DEBIAN_FRONTEND=noninteractive \
-    OPENIDC_VERSION=1.8.10.1 \
+    OPENIDC_VERSION=2.0.0 \
     PHUSION_BASEIMAGE=0.9.22
 
 ADD . /tmp/build


### PR DESCRIPTION
Obviously a major release of openidc but this version also introduces a significant change in library dependencies by requiring the library libcjose.

Based on statements on the openidc github site, this version is not recommended and you should be  using version 2.1.6 or higher.  However this PR is here in order to track with openidc github releases.  I do not plan on "cutting" a release (ie no 2.0.0 tag will be applied) based on this version.