### PR TITLE
bumped openidc to version 2.1.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM phusion/baseimage:0.9.22
 MAINTAINER Andrew Teixeira <teixeira@broadinstitute.org>
 
 ENV DEBIAN_FRONTEND=noninteractive \
-    OPENIDC_VERSION=2.0.0 \
+    OPENIDC_VERSION=2.1.0 \
     PHUSION_BASEIMAGE=0.9.22
 
 ADD . /tmp/build


### PR DESCRIPTION
As with 2.0.0 based on statements on the openidc github repo, this release is NOT recommended.  This PR is only for historical tracking with openidc github releases.  You should be using version 2.1.6 or higher.  No release will be created for this version.