### PR TITLE
bumped openidc version to 2.1.6, updated install-openidc.sh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM phusion/baseimage:0.9.22
 MAINTAINER Andrew Teixeira <teixeira@broadinstitute.org>
 
 ENV DEBIAN_FRONTEND=noninteractive \
-    OPENIDC_VERSION=2.1.0 \
+    OPENIDC_VERSION=2.1.6 \
     PHUSION_BASEIMAGE=0.9.22
 
 ADD . /tmp/build

--- a/install-openidc.sh
+++ b/install-openidc.sh
@@ -56,7 +56,7 @@ case ${OPENIDC_VERSION} in
         CJOSE_VERSION="0.4.1"
         CJOSE_OPENIDC_DIST_VERSION="2.1.0"
      ;;
-   2.1.3) 
+   2.1.3|2.1.4|2.1.5|2.1.6) 
         if [ "${pack}" = "xenial" ]
         then
            # no xenial package but wily works"
@@ -64,6 +64,24 @@ case ${OPENIDC_VERSION} in
         fi
         CJOSE_VERSION="0.4.1"
         CJOSE_OPENIDC_DIST_VERSION="2.1.3"
+     ;;
+    2.2.0)
+        if [ "${pack}" = "xenial" ]
+        then
+           # no xenial package but wily works"
+           pack="wily"
+        fi
+        CJOSE_VERSION="0.4.1"
+        CJOSE_OPENIDC_DIST_VERSION="2.2.0"
+     ;;
+    2.3.0|2.3.1)
+        if [ "${pack}" = "xenial" ]
+        then
+           # no xenial package but wily works"
+           pack="wily"
+        fi
+        CJOSE_VERSION="0.5.1"
+        CJOSE_OPENIDC_DIST_VERSION="2.3.0"
      ;;
 esac
    


### PR DESCRIPTION
This is the recommended version for the 2.0 and 2.1 release lines.  In addition to bumping the version, the install-openidc.sh script had to be updated to support all current released versions greater than 2.1.3 that exist on the openidc github repo site.

While earlier 2.1.x versions may be fine to run, this will be the first "release" of the 2.x version for the Broad.