### PR TITLE
bumped version to 2.3.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM phusion/baseimage:0.9.22
 MAINTAINER Andrew Teixeira <teixeira@broadinstitute.org>
 
 ENV DEBIAN_FRONTEND=noninteractive \
-    OPENIDC_VERSION=2.2.0 \
+    OPENIDC_VERSION=2.3.0 \
     PHUSION_BASEIMAGE=0.9.22
 
 ADD . /tmp/build


### PR DESCRIPTION
Since version 2.3.1 is  out, I am not planning on creating an official release for 2.3.0.  So this PR is just to track versions with openidc github releases.